### PR TITLE
Ignore virtual environment directories recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # Exclude Python virtual environment
 venv/
+**/venv/
+**/.venv/
 myenv/
 __pycache__/
 


### PR DESCRIPTION
## Summary
- Ignore Python virtual environment directories named `venv` or `.venv` at any depth via `.gitignore`.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68b40c2b17988327b7470163feb3e194