### PR TITLE
docs: add virtualenv setup and subproject links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Here is an implementation of regex for:
 * a+
 * b+
 
+## Python окружения
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Linux/macOS
+# .venv\Scripts\activate  # Windows
+pip install -r requirements.txt
+```
+
 ## NeuralNetworks module
 
 The `NeuralNetworks` package has been reorganized for clarity. It now
@@ -19,3 +28,9 @@ contains the following subdirectories:
 
 Each folder is a Python package thanks to the included `__init__.py`
 files, which enables relative imports between components.
+
+## Подпроекты
+
+- [NeuralNetworks](#neuralnetworks-module)
+- [asm](asm/README.md)
+- [google](google/README.md) ([requirements](google/requirements.txt))


### PR DESCRIPTION
## Summary
- describe creating and activating Python virtual environments and installing requirements
- list available subprojects and link to their docs and dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `pip install tensorflow` *(fails: Could not connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b40d8582e083278becc6b814a0184e