### PR TITLE
docs: add vector-matrix multiplication rules

### DIFF
--- a/math/README.md
+++ b/math/README.md
@@ -1,0 +1,20 @@
+# Math utilities
+
+This directory contains mathematical examples and utilities.
+
+## Умножение вектора на матрицу
+
+Для вектора-строки $\mathbf{v} = [v_1, v_2, \ldots, v_n]$ и матрицы $A$ размера $n \times m$ произведение $\mathbf{v}A$ определено, если длина вектора равна числу строк матрицы. Результатом будет вектор-строка $\mathbf{w}$ длины $m$, где
+
+$$w_j = \sum_{i=1}^{n} v_i A_{ij}.$$
+
+Пример:
+
+$$[v_1, v_2]
+\begin{bmatrix}
+ a_{11} & a_{12} \\
+ a_{21} & a_{22}
+\end{bmatrix}
+=
+[v_1 a_{11} + v_2 a_{21},\; v_1 a_{12} + v_2 a_{22}].$$
+


### PR DESCRIPTION
## Summary
- document vector-matrix multiplication in the math module

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `pip install tensorflow` *(fails: Could not find a version that satisfies the requirement tensorflow; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b414b63c6c8327b8b638c3e930f509